### PR TITLE
「句読点(。、)が閉じ括弧の直前に存在しています」と「連続した句読点(。、)が使われています」の優先順位修正

### DIFF
--- a/src/general-novel-style.js
+++ b/src/general-novel-style.js
@@ -79,15 +79,6 @@ function reporter(context, options = {}) {
                     }
                 }
 
-                if (noPunctuationAtClosingQuote) {
-                    reportMatches({
-                        pattern: /[。、]+(?=[」』】〉》）\)”"’'］\]〕｝\}＞>])/g,
-                        message: "句読点(。、)が閉じ括弧の直前に存在しています",
-                        indexer: (range) => range[1] - 1,
-                        fixer:   (range) => fixer.removeRange(range),
-                    });
-                }
-
                 if (spaceAfterMarks) {
                     reportMatches({
                         pattern: /[？！](?![　？！」』】〉》）\)”"’'］\]〕｝\}＞>]|$)/g,
@@ -135,6 +126,15 @@ function reporter(context, options = {}) {
                         pattern: /ーー+/g,
                         message: "連続した長音符(ー)が使われています",
                         fixer:   (range, s) => fixer.replaceTextRange(range, repeat("――", Math.ceil(s.length / 2))),
+                    });
+                }
+
+                if (noPunctuationAtClosingQuote) {
+                    reportMatches({
+                        pattern: /[。、]+(?=[」』】〉》）\)”"’'］\]〕｝\}＞>])/g,
+                        message: "句読点(。、)が閉じ括弧の直前に存在しています",
+                        indexer: (range) => range[1] - 1,
+                        fixer: (range) => fixer.removeRange(range),
                     });
                 }
 

--- a/test/general-novel-style-test.js
+++ b/test/general-novel-style-test.js
@@ -248,14 +248,14 @@ tester.run("general-novel-style", rule, {
             output: "「こんにちは、世界」",
             errors: [
                 {
-                    message: "句読点(。、)が閉じ括弧の直前に存在しています",
-                    line: 1,
-                    column: 12
-                },
-                {
                     message: "連続した句読点(。、)が使われています",
                     line: 1,
                     column: 10
+                },
+                {
+                    message: "句読点(。、)が閉じ括弧の直前に存在しています",
+                    line: 1,
+                    column: 12
                 }
             ]
         },


### PR DESCRIPTION
テストを実行すると以下のテストケースで失敗するので、指摘の優先順位を `連続した句読点(。、)が使われています` > `句読点(。、)が閉じ括弧の直前に存在しています` に変更します。

https://github.com/io-monad/textlint-rule-general-novel-style-ja/blob/6b1a52876842f1a07f1ea1b11d3af6d963bc20ce/test/general-novel-style-test.js#L246-L261

```
$ yarn test
...
  1) general-novel-style Fixer: 「こんにちは、世界。。。」:

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ '「こんにちは、世界……」'
- '「こんにちは、世界」'
            ^
      + expected - actual

      -「こんにちは、世界……」
      +「こんにちは、世界」
      
      at node_modules/textlint-tester/src/textlint-tester.js:72:28
```